### PR TITLE
Move benchmarks to their own directory

### DIFF
--- a/benches/benchmarks.rs
+++ b/benches/benchmarks.rs
@@ -1,0 +1,84 @@
+#![feature(test)]
+
+extern crate bigbang;
+extern crate test;
+
+use bigbang::{Entity, AsEntity, GravTree, max_min_xyz};
+
+#[bench]
+fn bench_time_step_05(b: &mut test::Bencher) {
+	let mut vec_that_wants_to_be_a_kdtree: Vec<Entity> = Vec::new();
+	for _ in 0..5 {
+		for _ in 0..5 {
+			for _ in 0..5 {
+				let entity = Entity::random_entity();
+				vec_that_wants_to_be_a_kdtree.push(entity);
+			}
+		}
+	}
+
+	let mut test_tree = GravTree::new(&mut vec_that_wants_to_be_a_kdtree, 0.2);
+	b.iter(|| test_tree = test_tree.time_step())
+}
+
+#[bench]
+fn bench_time_step_10(b: &mut test::Bencher) {
+	let mut vec_that_wants_to_be_a_kdtree: Vec<Entity> = Vec::new();
+	for _ in 0..10 {
+		for _ in 0..10 {
+			for _ in 0..10 {
+				let entity = Entity::random_entity();
+				vec_that_wants_to_be_a_kdtree.push(entity);
+			}
+		}
+	}
+
+	let mut test_tree = GravTree::new(&mut vec_that_wants_to_be_a_kdtree, 0.2);
+	b.iter(|| test_tree = test_tree.time_step())
+}
+
+#[bench]
+fn bench_time_step_12(b: &mut test::Bencher) {
+	let mut vec_that_wants_to_be_a_kdtree: Vec<Entity> = Vec::new();
+	for _ in 0..12 {
+		for _ in 0..12 {
+			for _ in 0..12 {
+				let entity = Entity::random_entity();
+				vec_that_wants_to_be_a_kdtree.push(entity);
+			}
+		}
+	}
+
+	let mut test_tree = GravTree::new(&mut vec_that_wants_to_be_a_kdtree, 0.2);
+	b.iter(|| test_tree = test_tree.time_step())
+}
+#[bench]
+fn bench_time_step_15(b: &mut test::Bencher) {
+	let mut vec_that_wants_to_be_a_kdtree: Vec<Entity> = Vec::new();
+	for _ in 0..15 {
+		for _ in 0..15 {
+			for _ in 0..15 {
+				let entity = Entity::random_entity();
+				vec_that_wants_to_be_a_kdtree.push(entity);
+			}
+		}
+	}
+
+	let mut test_tree = GravTree::new(&mut vec_that_wants_to_be_a_kdtree, 0.2);
+	b.iter(|| test_tree = test_tree.time_step())
+}
+
+#[bench]
+fn bench_max_min(b: &mut test::Bencher) {
+	let mut test_vec: Vec<Entity> = Vec::new();
+	for _ in 0..1000 {
+		test_vec.push(Entity::random_entity());
+	}
+
+	let ref_vec = test_vec
+		.iter()
+		.map(|x| x.as_entity())
+		.collect::<Vec<Entity>>();
+	// TODO make it do this with different vecs
+	b.iter(|| max_min_xyz(ref_vec.as_slice()));
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,6 @@
-#![feature(test)]
 extern crate either;
 extern crate rand;
 extern crate rayon;
-extern crate test;
 mod dimension;
 mod entity;
 mod gravtree;
@@ -16,6 +14,7 @@ use std::mem::transmute_copy;
 /*  public-facing entry points */
 pub use entity::{AsEntity, Entity};
 pub use gravtree::GravTree;
+pub use utilities::max_min_xyz;
 
 /* FFI interface functions are all plopped right here. */
 
@@ -177,67 +176,4 @@ fn go_to_edges(grav_tree: GravTree<Entity>, left_nodes: usize, right_nodes: usiz
         node2 = node2.right.expect("unexpected null node #2\n");
     }
     assert!(count_of_nodes == right_nodes);
-}
-
-#[bench]
-fn bench_time_step_05(b: &mut test::Bencher) {
-    let mut vec_that_wants_to_be_a_kdtree: Vec<Entity> = Vec::new();
-    for _ in 0..5 {
-        for _ in 0..5 {
-            for _ in 0..5 {
-                let entity = Entity::random_entity();
-                vec_that_wants_to_be_a_kdtree.push(entity);
-            }
-        }
-    }
-
-    let mut test_tree = GravTree::new(&mut vec_that_wants_to_be_a_kdtree, 0.2);
-    b.iter(|| test_tree = test_tree.time_step())
-}
-
-#[bench]
-fn bench_time_step_10(b: &mut test::Bencher) {
-    let mut vec_that_wants_to_be_a_kdtree: Vec<Entity> = Vec::new();
-    for _ in 0..10 {
-        for _ in 0..10 {
-            for _ in 0..10 {
-                let entity = Entity::random_entity();
-                vec_that_wants_to_be_a_kdtree.push(entity);
-            }
-        }
-    }
-
-    let mut test_tree = GravTree::new(&mut vec_that_wants_to_be_a_kdtree, 0.2);
-    b.iter(|| test_tree = test_tree.time_step())
-}
-
-#[bench]
-fn bench_time_step_12(b: &mut test::Bencher) {
-    let mut vec_that_wants_to_be_a_kdtree: Vec<Entity> = Vec::new();
-    for _ in 0..12 {
-        for _ in 0..12 {
-            for _ in 0..12 {
-                let entity = Entity::random_entity();
-                vec_that_wants_to_be_a_kdtree.push(entity);
-            }
-        }
-    }
-
-    let mut test_tree = GravTree::new(&mut vec_that_wants_to_be_a_kdtree, 0.2);
-    b.iter(|| test_tree = test_tree.time_step())
-}
-#[bench]
-fn bench_time_step_15(b: &mut test::Bencher) {
-    let mut vec_that_wants_to_be_a_kdtree: Vec<Entity> = Vec::new();
-    for _ in 0..15 {
-        for _ in 0..15 {
-            for _ in 0..15 {
-                let entity = Entity::random_entity();
-                vec_that_wants_to_be_a_kdtree.push(entity);
-            }
-        }
-    }
-
-    let mut test_tree = GravTree::new(&mut vec_that_wants_to_be_a_kdtree, 0.2);
-    b.iter(|| test_tree = test_tree.time_step())
 }

--- a/src/utilities.rs
+++ b/src/utilities.rs
@@ -22,21 +22,6 @@ pub fn max_min_xyz(entities: &[Entity]) -> (&f64, &f64, &f64, &f64, &f64, &f64) 
     (x_max, x_min, y_max, y_min, z_max, z_min)
 }
 
-#[bench]
-fn bench_max_min(b: &mut test::Bencher) {
-    let mut test_vec: Vec<Entity> = Vec::new();
-    for _ in 0..1000 {
-        test_vec.push(Entity::random_entity());
-    }
-
-    let ref_vec = test_vec
-        .iter()
-        .map(|x| x.as_entity())
-        .collect::<Vec<Entity>>();
-    // TODO make it do this with different vecs
-    b.iter(|| max_min_xyz(ref_vec.as_slice()));
-}
-
 /// Returns the maximum and minimum values in a slice of entities, given a dimension.
 pub fn max_min(dim: Dimension, entities: &[Entity]) -> (&f64, &f64) {
     (


### PR DESCRIPTION
Hi! I really appreciate your library. This PR moves the benchmarks to their own special directory. This means that you no longer need to use the nightly version of rust to compile the code due to `#![feature(test)]` being unstable. This unfortunately means that you have to expose `max_min_xyz` as a public module, which is a bit awkward though.